### PR TITLE
Contributing to R initial content

### DIFF
--- a/_layouts/custom.html
+++ b/_layouts/custom.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <link rel="icon" type="image/png"  href="assets/img/favicon.png">
+    <link rel="icon" type="image/png"  href="{{ 'assets/img/favicon.png' | relative_url }}">
     <!-- changed title -->
     <title>{{ site.title | default: site.github.repository_name }}</title>
     <!-- change end -->

--- a/contributing-to-r/index.md
+++ b/contributing-to-r/index.md
@@ -1,0 +1,6 @@
+---
+layout: custom
+---
+
+# Contributing to R
+

--- a/tutorials.md
+++ b/tutorials.md
@@ -4,6 +4,18 @@ layout: custom
 
 # Tutorials
 
+## Contributing to R
+
+Prepared by Gabriel Becker and Martin Maechler.
+
+Did you always want to contribute to (base) R but don't know how?
+
+In this video tutorial recorded at useR! 2021, Gabriel Becker and Martin Maechler show cases where and how users have contributed actively to (base) R, by submitting bug reports with minimal reproducible examples, how testing, reading source code, and providing patches to the R source code has helped making R better.
+
+A selection of past bug reports are provided for you to practice debugging. For bugs that have been resolved you can check what happened after the bug was reported.
+
+[Contributing to R tutorial](contributing-to-r)
+
 ## Translating R to your Language
 
 Prepared by Michael Chirico and Michael Lawrence.


### PR DESCRIPTION
Added initial structure for adding contributing to R tutorial.

Next steps:

1. Edit `/contributing-to-r/index.md` to

- [ ]  Embed YouTube video (https://www.youtube.com/watch?v=CZmldTOdlRM&list=PL4IzsxWztPdnCC_kMCYKrd_t6cViMhBrD&index=7&t=4036s), being sure to embed without cookies (https://cookie-script.com/blog/how-to-add-youtube-videos-without-cookies).
- [ ] Add link to presentation slides.
- [ ] Add any text around this material as you see fit (maybe all of https://github.com/gmbecker/contributing_to_r_lesson from "Preparing for the Session" onwards? Ideally edit to use meaningful link text for all hyperlinks.)

2. Check the text on `/tutorials.md` - currently a lightly edited version of the useR! 2021 tutorial abstract.

You can see what has been done for the Translating R tutorial as an example.