### PR TITLE
Update macOS install instructions

### DIFF
--- a/working_documents/install_r_macos.Rmd
+++ b/working_documents/install_r_macos.Rmd
@@ -46,11 +46,11 @@ running `install.libs("r-base-dev")`, e.g. "Can't restore time",
     matches your architecture:
     ```{sh}
 # Intel
-export PATH="/opt/R/x86_64/bin:\${PATH}"
+export PATH="/opt/R/x86_64/bin:${PATH}"
     ```
     ```{sh}
 # Apple Silicon (M1, M2, ...)
-export PATH="/opt/R/arm64/bin:\${PATH}"
+export PATH="/opt/R/arm64/bin:${PATH}"
     ```
     This will add the `/opt/R/*/bin` directory to your `PATH` variable 
     when you restart Terminal.app, so that the prerequisites 


### PR DESCRIPTION
Remove unnecessary backslashes from `PATH` variable in draft macOS installation guide.